### PR TITLE
Fix account errors to match with the server specs

### DIFF
--- a/react-app/src/account/index.js
+++ b/react-app/src/account/index.js
@@ -38,19 +38,22 @@ class Account {
   }
 
   toString() {
+    const pkAsArray = Array.from(this._pk);
     return JSON.stringify({
-      username: this._username,
-      pk: this._pk,
-      tz: this._tz,
-      offset: this._offset
+      Username: this._username,
+      Pk: pkAsArray,
+      Tz: this._tz,
+      Offset: this._offset
     });
   }
 
   _generateNonce(publicKeyA, publicKeyB) {
-    let state = blake.blake2bInit(nacl.box.nonceLength, null);
+    const nonceComputeLength = 32;
+    const nonceExpectedLength = 24;
+    let state = blake.blake2bInit(nonceComputeLength, null);
     blake.blake2bUpdate(state, publicKeyA);
     blake.blake2bUpdate(state, publicKeyB);
-    return blake.blake2bFinal(state);
+    return blake.blake2bFinal(state).subarray(0, nonceExpectedLength);
   }
 
   encrypt(plainText) {


### PR DESCRIPTION
1. JSON.stringify() of a TypedArray gives a JSON object instead of
a JSON array -which is expected by the server-. This issue is solve
by this commit.

2. JSON keys are now written in capital letters.

3. Fix nonce generation to match with the server.