### PR TITLE
Add support to absolite paths to eslint

### DIFF
--- a/react-app/.eslintrc.yaml
+++ b/react-app/.eslintrc.yaml
@@ -35,4 +35,6 @@ globals:
 settings:
   import/resolver:
     node:
-      paths: "src"
+      moduleDirectory:
+        - node_modules
+        - src/


### PR DESCRIPTION
With this change, absolute paths are recognized by eslint and no _"Unable to resolve path to module"_ error is shown when using absolute paths.