### PR TITLE
Restore saved account once the app is re-opened

### DIFF
--- a/react-app/src/AppRouter.js
+++ b/react-app/src/AppRouter.js
@@ -1,7 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { HashRouter, Route } from 'react-router-dom';
 
 import LocaleHOC from 'locale/LocaleHOC';
+
+import { initSavedAccountAsync } from 'actions/account';
+
+import { showLoadingModal, hideLoadingModal } from 'utils/spinner';
 
 import EditScreenContainer from 'containers/EditScreenContainer';
 import ListScreenContainer from 'containers/ListScreenContainer';
@@ -20,6 +26,25 @@ function changeHash(hash) {
 }
 
 class AppRouter extends React.PureComponent {
+  static propTypes = {
+    /**
+     * Redux dispatch function
+     */
+    dispatch: PropTypes.func.isRequired,
+  };
+
+  async componentDidMount() {
+    try {
+      showLoadingModal('Loading');
+      const savedAccountInited = await this.props.dispatch(initSavedAccountAsync());
+      if (savedAccountInited) changeHash(SCREENS_HASHES.list);
+    } catch (error) {
+      /** Nothing to be done here */
+    } finally {
+      hideLoadingModal();
+    }
+  }
+
   render() {
     return (
       LocaleHOC(
@@ -37,4 +62,4 @@ class AppRouter extends React.PureComponent {
 }
 
 export { changeHash, SCREENS_HASHES }
-export default AppRouter;
+export default connect()(AppRouter);

--- a/react-app/src/actions/account.js
+++ b/react-app/src/actions/account.js
@@ -1,7 +1,7 @@
 import Account from 'account';
 import api from 'api';
 
-import { DAILY } from 'notifications';
+import { getSchedule, DAILY } from 'notifications';
 
 export const SIGN_IN = 'SIGN_IN';
 export const SIGN_OUT = 'SIGN_OUT';
@@ -45,4 +45,18 @@ export const signUpAsync = async (username, password) => {
   const signedUp = await api.signUp();
 
   return signedUp;
+}
+
+export const initSavedAccountAsync = () => async dispatch => {
+  try {
+    const savedAccountUsername = await api.initSavedAccount();
+    if (!savedAccountUsername) return false;
+
+    const notifications = await getSchedule();
+    dispatch(signIn(savedAccountUsername, notifications));
+
+    return true;
+  } catch (error) {
+    return false;
+  }
 }

--- a/react-app/src/api/index.js
+++ b/react-app/src/api/index.js
@@ -155,9 +155,11 @@ class Api {
         publicKey: Uint8Array.from(deserializedSavedAccount.publicKey),
         secretKey: Uint8Array.from(deserializedSavedAccount.secretKey),
       };
+      const savedKey = Uint8Array.from(deserializedSavedAccount.key);
 
       this._token = savedToken;
       this.initAccount(savedAccountUsername, savedAccountKeyPair);
+      this._account.key = savedKey;
 
       savedAccountSuccessfulyInitialized = true;
     } catch (error) {

--- a/react-app/src/api/index.js
+++ b/react-app/src/api/index.js
@@ -141,7 +141,7 @@ class Api {
   }
 
   async initSavedAccount() {
-    let savedAccountSuccessfulyInitialized = false;
+    let savedAccountUsername = "";
 
     try {
       await keystore.init();
@@ -150,7 +150,7 @@ class Api {
 
       const deserializedSavedAccount = JSON.parse(serializedSavedAccount);
 
-      const savedAccountUsername = deserializedSavedAccount.username;
+      savedAccountUsername = deserializedSavedAccount.username;
       const savedAccountKeyPair = {
         publicKey: Uint8Array.from(deserializedSavedAccount.publicKey),
         secretKey: Uint8Array.from(deserializedSavedAccount.secretKey),
@@ -160,13 +160,11 @@ class Api {
       this._token = savedToken;
       this.initAccount(savedAccountUsername, savedAccountKeyPair);
       this._account.key = savedKey;
-
-      savedAccountSuccessfulyInitialized = true;
     } catch (error) {
       /* Nothing here. If the account data cannot be loaded, the app works normally and user must signin */
     }
 
-    return savedAccountSuccessfulyInitialized;
+    return savedAccountUsername;
   }
 }
 


### PR DESCRIPTION
PR #43 added support to use the keystore/keychain. This PR, integrate this utility into the app-flow to restore a saved account and so, avoid the need of signing in all the times when the user opens the app.