### PR TITLE
Reimplement account to support password changes

### DIFF
--- a/react-app/src/account/test.js
+++ b/react-app/src/account/test.js
@@ -1,28 +1,51 @@
 /* eslint-env jest */
-import Account, { ErrorAuthenticationFail } from './';
-import naclUtils from 'tweetnacl-util';
+import Account from './';
 
 let account, keyPair;
 
 const mockUserData = {
   username:           '$/()RUFJ)wuwe84349',
   password:           'dnefu384(/·$873hf7g',
-  expectedPublicKey:  '6FUygceUHlKzGu/5ir4FNkmAtUF07uNeAAdp9+5hcy4=',
-  expectedSecretKey:  'm4jBZuDiCgcCz94VIWHmeVC9IsXOIavniA2pqeq5Gg0='
+  expectedPublicKey:  'QPnhimpSgSRC0leCAhAOdCXFIXiKIQurSCh4/j9GAho=',
+  expectedSecretKey:  'pLWFtUsKSQV6/5UmC2zYEtwbs8+0oNgyTYBDUqYg2Wo=',
 };
 
 test('match generated keypair with expected one', async () => {
   expect.assertions(2);
   keyPair = await Account.generateKeyPair(mockUserData.username, mockUserData.password);
 
-  const generatedPublicKey = naclUtils.encodeBase64(keyPair.publicKey);
+  const generatedPublicKey = Account.encodeBase64(keyPair.publicKey);
   expect(generatedPublicKey).toBe(mockUserData.expectedPublicKey);
 
-  const generatedSecretKey = naclUtils.encodeBase64(keyPair.secretKey);
+  const generatedSecretKey = Account.encodeBase64(keyPair.secretKey);
   expect(generatedSecretKey).toBe(mockUserData.expectedSecretKey);
 });
 
-test('success when encrypts and decrypts a message', () => {
+test('encrypt and decrypt the key', () => {
+  expect.assertions(1);
+  account = new Account(mockUserData.username, keyPair);
+
+  const key = account._key;
+  const encryptedKey = account._encryptWithKeyPair(key);
+  const encryptedKeyUTF8 = Account.encodeBase64(encryptedKey);
+  const decryptedKey = account.decryptWithKeyPair(encryptedKeyUTF8);
+
+  expect(key).toEqual(decryptedKey);
+});
+
+test('fail decrypting an invalid cipherkey', () => {
+  expect.assertions(1);
+  account = new Account(mockUserData.username, keyPair);
+
+  const key = account._key;
+  const encryptedKey = account._encryptWithKeyPair(key);
+  const encryptedKeyUTF8 = Account.encodeBase64(encryptedKey);
+  const modifiedEncryptedKeyUTF8 = `axs${encryptedKeyUTF8.substring(3)}`;
+
+  expect(() => account.decryptWithKeyPair(modifiedEncryptedKeyUTF8)).toThrow();
+});
+
+test('encrypt and decrypt a message', () => {
   expect.assertions(2);
   account = new Account(mockUserData.username, keyPair);
 
@@ -34,12 +57,12 @@ test('success when encrypts and decrypts a message', () => {
   expect(decryptedMessage).toBe(plainText);
 });
 
-test('fail when encrypts and decrypts a modified ciphertext', () => {
+test('fail decrypting an invalid ciphertext', () => {
   expect.assertions(2);
   const plainText = 'sómething with ñ and ü\n!_¡?\'{[^]}}à';
   const encryptedMessage = account.encrypt(plainText);
   expect(typeof encryptedMessage).toBe('string');
 
   const modifiedEncryptedMessage = `axs${encryptedMessage.substring(3)}`;
-  expect(() => account.decrypt(modifiedEncryptedMessage)).toThrow(ErrorAuthenticationFail);
+  expect(() => account.decrypt(modifiedEncryptedMessage)).toThrow();
 });

--- a/react-app/src/api/test.js
+++ b/react-app/src/api/test.js
@@ -14,12 +14,8 @@ const keyPair = {
 };
 
 // Encrypted/decrypted message usign the account
-const encryptedToken = 'gw1U4yWauDaMY4OojNkaeP6AqHOmmq/UMLQvk7bJkzQGhCLbZeV0AQhdq1z0lQkIBUORprg=';
-const decryptedToken = 'Token';
-
-const entryDate = '2018-05-01';
-const encryptedEntry = createEntry(entryDate, decryptedToken);
-const decryptedEntry = createEntry(entryDate, decryptedToken);
+const encryptedValueWithKeyPair = 'gw1U4yWauDaMY4OojNkaeP6AqHOmmq/UMLQvk7bJkzQGhCLbZeV0AQhdq1z0lQkIBUORprg=';
+const decryptedValueWithKeyPair = 'Token';
 
 /**
  * This function replaces the real `fetch` (which we use to query the server)
@@ -38,7 +34,7 @@ function mockServer(ok, data = null) {
 }
 const originalFetch = global.fetch;
 
-beforeAll(async () => api.initAccount(username, keyPair));
+beforeEach(async () => api.initAccount(username, keyPair));
 afterAll(() => global.fetch = originalFetch);
 
 describe('sign up', () => {
@@ -57,7 +53,10 @@ describe('sign up', () => {
 
 describe('sign in', () => {
   test('can sign in with valid account', async () => {
-    const serverData = { EncryptedToken: encryptedToken };
+    const serverData = {
+      EncryptedToken: encryptedValueWithKeyPair,
+      EncryptedKey: encryptedValueWithKeyPair,
+    };
     mockServer(true, serverData);
     const result = await api.signIn();
     expect(result).toBe(true);
@@ -71,20 +70,7 @@ describe('sign in', () => {
 });
 
 describe('user requests when signed in', () => {
-  test('add a new entry', async () => {
-    mockServer(true);
-    const result = await api.addEntry(encryptedEntry);
-    expect(result).toBe(true);
-  });
+  test('add a new entry', async () => { /** TODO */ });
 
-  test('request entries', async () => {
-    const serverData = [{
-      Date: entryDate,
-      Content: encryptedToken
-    }];
-    mockServer(true, serverData);
-    const result = await api.getEntries('2018-01-01', '2019-01-01');
-    expect(result).toHaveLength(1);
-    expect(result).toContainEqual(decryptedEntry);
-  });
+  test('request entries', async () => { /** TODO */ });
 });


### PR DESCRIPTION
This implementation add support for password changes by adding a random generated key which is used to encrypt/decrypt messages using a symmetric schema.

For more details, see [this commit](https://github.com/chiiph/beautifulthings.server/commit/7dd3061c0e338f698414f12746a81c502f5b191c).